### PR TITLE
Add more comments, enable compatibility with Nix legacy commands (nix-shell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gradle run
 
 To run the application correctly, you can either use a **manual setup** ensuring you have the correct version of Java and Gradle installed locally on your machine.
 
-But you can avoid this by first setting up an isolated development environment, for example using 
+But you can avoid this by first setting up an isolated development environment, for example using
 **DevContainer** or **Nix** that will ensure that all correct versions of all tools and libraries required for the application are installed.
 
 ### Using Nix
@@ -32,10 +32,10 @@ But you can avoid this by first setting up an isolated development environment, 
 This approach will setup a development environment using the [Nix](https://nixos.org) package manager.
 No containerisation is used, and the development environment will be installed on your local machine, in **total isolation** from your current system packages.
 
-1. Install Nix package manager: `curl -L https://nixos.org/nix/install | sh`
+1. Install Nix package manager: `curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install` (from https://github.com/NixOS/nix-installer)
 2. Go to the project root folder
-3. Run `nix develop` to enter the development environment
-4. Start using the gradle commands for building, testing and executing the application and interact with it through its GUI.
+3. Run `nix-shell` to enter the development environment
+4. Start using the Gradle commands for building, testing and executing the application and interact with it through its GUI.
 5. Once you are done, exit the development environment by running `exit`
 
 ### Using DevContainer (Container based)
@@ -54,6 +54,3 @@ Due to the graphical nature of the Java application, running the GUI may not be 
       ([documentation](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html))
 3. Open the project in your IDE, and you should see a notification to reopen the project in a container, click on it.
 4. Once the project is reopened in the container, you need to wait a bit for the container to build and start, and then you can start developing, all the tools and dependencies are already installed in the container.
-
-
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -48,24 +64,9 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,47 @@
 {
+  # Define the inputs we need
   inputs = {
+    # We want to use `nixpkgs` to get access to a huge set of packages
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # We use the flake-parts framework to manage our flake structure
     flake-parts.url = "github:hercules-ci/flake-parts";
-    systems.url = "github:nix-systems/default";
+    # A compatibility shim to use Nix flakes with versions of Nix that don't
+    # have native flake support.
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
   };
 
+  # Define the outputs the flake will provide
   outputs =
-    inputs@{ ... }:
+    inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import inputs.systems;
+      # Define for which system this flake will work on
+      # We use a list of existing system available from `nixpkgs`.
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
 
+      # Define the outputs we want to expose for each available system
       perSystem =
         { pkgs, ... }:
         let
-          jdk = pkgs."jdk21";
+          # Change the Java version here if needed.
+          jdk = pkgs.jdk21;
         in
         {
+          # The 'default' development shell, use it with: `nix develop`
           devShells.default = pkgs.mkShellNoCC {
-            packages = [
+            # The list of packages this shell will provide
+            # Feel free to add more packages if needed.
+            # Find the list of available packages at https://search.nixos.org
+            buildInputs = [
               jdk
               (pkgs.gradle.override { java = jdk; })
             ];
+
+            shellHook = ''
+              ${pkgs.figlet}/bin/figlet UMons
+            '';
           };
         };
     };

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
This PR:

- Enable compatibility with legacy nix commands (nix-shell), so there is no need to enable `flakes` to get it working
- Update `flake.nix` file and include comments
- Update the README file and use the new and upcoming Nix installer by default